### PR TITLE
Typedefs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "util.h": "c",
+        "srcpos.h": "c",
+        "dtc.h": "c"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This specific repo exists as a place for proposed changes to dtc. Those changes 
 - [X] moving configuration options into a struct for per-operation configuration
   - [X] write struct
   - [X] Find all locations where the old global variables were used by dtc and replace them with config struct pointers `dtc_options_handle_t`. 
-- [ ] typedef'ing various structs 
-  - [ ] typedef the structs
-    - WIP
-  - [ ] modify function signatures to use the typedefs instead of `struct x` or `struct x *y`
+- [X] typedef'ing various structs 
+  - [X] typedef the structs
+  - [X] modify function signatures to use the typedefs instead of `struct x` or `struct x *y`
 - [ ] altering some functions so that the upcoming API implementation isn't built on the assumption of being a one-and-done program
+  - WIP ; started already because some parts of the previous step bled into this one
 - [ ] add to and modify existing documentation for the functions updated as a part of the previous step
 - [ ] add a C API for dtc
 - [ ] add make target for building a "libdtc" library and add to target `clean`

--- a/data.c
+++ b/data.c
@@ -5,10 +5,10 @@
 
 #include "dtc.h"
 
-void data_free(struct data d)
+void data_free(data_t d)
 {
-	marker_handle_t m;
-	marker_handle_t nm;
+	marker_t *m;
+	marker_t *nm;
 
 	m = d.markers;
 	while (m) {
@@ -22,9 +22,9 @@ void data_free(struct data d)
 		free(d.val);
 }
 
-struct data data_grow_for(struct data d, unsigned int xlen)
+data_t data_grow_for(data_t d, unsigned int xlen)
 {
-	struct data nd;
+	data_t nd;
 	unsigned int newsize;
 
 	if (xlen == 0)
@@ -42,9 +42,9 @@ struct data data_grow_for(struct data d, unsigned int xlen)
 	return nd;
 }
 
-struct data data_copy_mem(const char *mem, int len)
+data_t data_copy_mem(const char *mem, int len)
 {
-	struct data d;
+	data_t d;
 
 	d = data_grow_for(empty_data, len);
 
@@ -54,10 +54,10 @@ struct data data_copy_mem(const char *mem, int len)
 	return d;
 }
 
-struct data data_copy_escape_string(const char *s, int len)
+data_t data_copy_escape_string(const char *s, int len)
 {
 	int i = 0;
-	struct data d;
+	data_t d;
 	char *q;
 
 	d = data_add_marker(empty_data, TYPE_STRING, NULL);
@@ -77,9 +77,9 @@ struct data data_copy_escape_string(const char *s, int len)
 	return d;
 }
 
-struct data data_copy_file(FILE *f, size_t maxlen)
+data_t data_copy_file(FILE *f, size_t maxlen)
 {
-	struct data d = empty_data;
+	data_t d = empty_data;
 
 	d = data_add_marker(d, TYPE_NONE, NULL);
 	while (!feof(f) && (d.len < maxlen)) {
@@ -105,7 +105,7 @@ struct data data_copy_file(FILE *f, size_t maxlen)
 	return d;
 }
 
-struct data data_append_data(struct data d, const void *p, int len)
+data_t data_append_data(data_t d, const void *p, int len)
 {
 	d = data_grow_for(d, len);
 	memcpy(d.val + d.len, p, len);
@@ -113,7 +113,7 @@ struct data data_append_data(struct data d, const void *p, int len)
 	return d;
 }
 
-struct data data_insert_at_marker(struct data d, marker_handle_t m,
+data_t data_insert_at_marker(data_t d, marker_t *m,
 				  const void *p, int len)
 {
 	d = data_grow_for(d, len);
@@ -128,9 +128,9 @@ struct data data_insert_at_marker(struct data d, marker_handle_t m,
 	return d;
 }
 
-static struct data data_append_markers(struct data d, marker_handle_t m)
+static data_t data_append_markers(data_t d, marker_t *m)
 {
-	marker_handle_t *mp = &d.markers;
+	marker_t **mp = &d.markers;
 
 	/* Find the end of the markerlist */
 	while (*mp)
@@ -139,10 +139,10 @@ static struct data data_append_markers(struct data d, marker_handle_t m)
 	return d;
 }
 
-struct data data_merge(struct data d1, struct data d2)
+data_t data_merge(data_t d1, data_t d2)
 {
-	struct data d;
-	marker_handle_t m2 = d2.markers;
+	data_t d;
+	marker_t *m2 = d2.markers;
 
 	d = data_append_markers(data_append_data(d1, d2.val, d2.len), m2);
 
@@ -156,7 +156,7 @@ struct data data_merge(struct data d1, struct data d2)
 	return d;
 }
 
-struct data data_append_integer(struct data d, uint64_t value, int bits)
+data_t data_append_integer(data_t d, uint64_t value, int bits)
 {
 	uint8_t value_8;
 	fdt16_t value_16;
@@ -185,7 +185,7 @@ struct data data_append_integer(struct data d, uint64_t value, int bits)
 	}
 }
 
-struct data data_append_re(struct data d, uint64_t address, uint64_t size)
+data_t data_append_re(data_t d, uint64_t address, uint64_t size)
 {
 	struct fdt_reserve_entry re;
 
@@ -195,22 +195,22 @@ struct data data_append_re(struct data d, uint64_t address, uint64_t size)
 	return data_append_data(d, &re, sizeof(re));
 }
 
-struct data data_append_cell(struct data d, cell_t word)
+data_t data_append_cell(data_t d, cell_t word)
 {
 	return data_append_integer(d, word, sizeof(word) * 8);
 }
 
-struct data data_append_addr(struct data d, uint64_t addr)
+data_t data_append_addr(data_t d, uint64_t addr)
 {
 	return data_append_integer(d, addr, sizeof(addr) * 8);
 }
 
-struct data data_append_byte(struct data d, uint8_t byte)
+data_t data_append_byte(data_t d, uint8_t byte)
 {
 	return data_append_data(d, &byte, 1);
 }
 
-struct data data_append_zeroes(struct data d, int len)
+data_t data_append_zeroes(data_t d, int len)
 {
 	d = data_grow_for(d, len);
 
@@ -219,15 +219,15 @@ struct data data_append_zeroes(struct data d, int len)
 	return d;
 }
 
-struct data data_append_align(struct data d, int align)
+data_t data_append_align(data_t d, int align)
 {
 	int newlen = ALIGN(d.len, align);
 	return data_append_zeroes(d, newlen - d.len);
 }
 
-struct data data_add_marker(struct data d, enum markertype type, char *ref)
+data_t data_add_marker(data_t d, enum markertype type, char *ref)
 {
-	marker_handle_t m;
+	marker_t *m;
 
 	m = xmalloc(sizeof(*m));
 	m->offset = d.len;
@@ -238,7 +238,7 @@ struct data data_add_marker(struct data d, enum markertype type, char *ref)
 	return data_append_markers(d, m);
 }
 
-bool data_is_one_string(struct data d)
+bool data_is_one_string(data_t d)
 {
 	int i;
 	int len = d.len;

--- a/dtc-lexer.l
+++ b/dtc-lexer.l
@@ -23,7 +23,8 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-extern bool treesource_error;
+extern int yylex(bool *treesource_error);
+#define YY_DECL int yylex(bool *treesource_error)
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \
@@ -46,7 +47,7 @@ static int dts_version = 1;
 
 static void push_input_file(const char *filename);
 static bool pop_input_file(void);
-static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
+static void PRINTF(2, 3) lexical_error(bool *treesource_error, const char *fmt, ...);
 
 %}
 
@@ -59,7 +60,7 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
 
 <*>^"#"(line)?[ \t]+[0-9]+[ \t]+{STRING}([ \t]+[0-9]+)* {
 			char *line, *fnstart, *fnend;
-			struct data fn;
+			data_t fn;
 			/* skip text before line # */
 			line = yytext;
 			while (!isdigit((unsigned char)*line))
@@ -79,7 +80,7 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
 
 			/* Don't allow nuls in filenames */
 			if (memchr(fn.val, '\0', fn.len - 1))
-				lexical_error("nul in line number directive");
+				lexical_error(treesource_error, "nul in line number directive");
 
 			/* -1 since #line is the number of the next line */
 			srcpos_set_line(xstrdup(fn.val), atoi(line) - 1);
@@ -159,12 +160,12 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
 			yylval.integer = strtoull(yytext, &e, 0);
 
 			if (*e && e[strspn(e, "UL")]) {
-				lexical_error("Bad integer literal '%s'",
+				lexical_error(treesource_error, "Bad integer literal '%s'",
 					      yytext);
 			}
 
 			if (errno == ERANGE)
-				lexical_error("Integer literal '%s' out of range",
+				lexical_error(treesource_error, "Integer literal '%s' out of range",
 					      yytext);
 			else
 				/* ERANGE is the only strtoull error triggerable
@@ -174,18 +175,18 @@ static void PRINTF(1, 2) lexical_error(const char *fmt, ...);
 		}
 
 <*>{CHAR_LITERAL}	{
-			struct data d;
+			data_t d;
 			DPRINT("Character literal: %s\n", yytext);
 
 			d = data_copy_escape_string(yytext+1, yyleng-2);
 			if (d.len == 1) {
-				lexical_error("Empty character literal");
+				lexical_error(treesource_error, "Empty character literal");
 				yylval.integer = 0;
 			} else {
 				yylval.integer = (unsigned char)d.val[0];
 
 				if (d.len > 2)
-					lexical_error("Character literal has %d"
+					lexical_error(treesource_error, "Character literal has %d"
 						      " characters instead of 1",
 						      d.len - 1);
 			}
@@ -285,7 +286,7 @@ static bool pop_input_file(void)
 	return true;
 }
 
-static void lexical_error(const char *fmt, ...)
+static void lexical_error(bool *treesource_error, const char *fmt, ...)
 {
 	va_list ap;
 
@@ -293,5 +294,5 @@ static void lexical_error(const char *fmt, ...)
 	srcpos_verror(&yylloc, "Lexical error", fmt, ap);
 	va_end(ap);
 
-	treesource_error = true;
+	*treesource_error = true;
 }

--- a/dtc-parser.y
+++ b/dtc-parser.y
@@ -591,5 +591,6 @@ subnode:
 
 void yyerror(dt_info_t *dti, bool *treesource_error, char const *s)
 {
+	YY_USE(dti);
 	ERROR(&yylloc, "%s", s);
 }

--- a/dtc-parser.y
+++ b/dtc-parser.y
@@ -11,18 +11,15 @@
 #include "dtc.h"
 #include "srcpos.h"
 
-extern int yylex(void);
-extern void yyerror(char const *s);
+extern int yylex(bool *treesource_error);
+extern void yyerror(dt_info_t *dti, bool *treesource_error, char const *s);
 #define ERROR(loc, ...) \
 	do { \
 		srcpos_error((loc), "Error", __VA_ARGS__); \
-		treesource_error = true; \
+		*treesource_error = true; \
 	} while (0)
 
-#define YYERROR_CALL(msg) yyerror(msg)
-
-extern struct dt_info *parser_output;
-extern bool treesource_error;
+#define YYERROR_CALL(dti, tse, msg) yyerror(dti, tse, msg)
 
 static bool is_ref_relative(const char *ref)
 {
@@ -35,18 +32,18 @@ static bool is_ref_relative(const char *ref)
 	char *propnodename;
 	char *labelref;
 	uint8_t byte;
-	struct data data;
+	data_t data;
 
 	struct {
-		struct data	data;
+		data_t	data;
 		int		bits;
 	} array;
 
-	struct property *prop;
-	struct property *proplist;
-	struct node *node;
-	struct node *nodelist;
-	struct reserve_info *re;
+	property_t *prop;
+	property_t *proplist;
+	node_t *node;
+	node_t *nodelist;
+	reserve_info_t *re;
 	uint64_t integer;
 	unsigned int flags;
 }
@@ -68,6 +65,10 @@ static bool is_ref_relative(const char *ref)
 %token <labelref> DT_LABEL_REF
 %token <labelref> DT_PATH_REF
 %token DT_INCBIN
+
+%parse-param { dt_info_t *dti }
+%parse-param { bool *treesource_error }
+%lex-param { bool *treesource_error }
 
 %type <data> propdata
 %type <data> propdataprefix
@@ -106,8 +107,8 @@ static bool is_ref_relative(const char *ref)
 sourcefile:
 	  headers memreserves devicetree
 		{
-			parser_output = build_dt_info($1, $2, $3,
-			                              guess_boot_cpuid($3));
+			build_dt_info(dti, $1, $2, $3,
+			              guess_boot_cpuid($3));
 		}
 	;
 
@@ -184,7 +185,7 @@ devicetree:
 		}
 	| devicetree DT_LABEL dt_ref nodedef
 		{
-			struct node *target = get_node_by_ref($1, $3);
+			node_t *target = get_node_by_ref($1, $3);
 
 			if (($<flags>-1 & DTSF_PLUGIN) && is_ref_relative($3))
 				ERROR(&@2, "Label-relative reference %s not supported in plugin", $3);
@@ -208,7 +209,7 @@ devicetree:
 					ERROR(&@2, "Label-relative reference %s not supported in plugin", $2);
 				add_orphan_node($1, $3, $2);
 			} else {
-				struct node *target = get_node_by_ref($1, $2);
+				node_t *target = get_node_by_ref($1, $2);
 
 				if (target)
 					merge_nodes(target, $3);
@@ -219,7 +220,7 @@ devicetree:
 		}
 	| devicetree DT_LABEL_REF nodedef
 		{
-			struct node *target = get_node_by_ref($1, $2);
+			node_t *target = get_node_by_ref($1, $2);
 
 			if (target) {
 				merge_nodes(target, $3);
@@ -238,7 +239,7 @@ devicetree:
 		}
 	| devicetree DT_DEL_NODE dt_ref ';'
 		{
-			struct node *target = get_node_by_ref($1, $3);
+			node_t *target = get_node_by_ref($1, $3);
 
 			if (target)
 				delete_node(target);
@@ -250,7 +251,7 @@ devicetree:
 		}
 	| devicetree DT_OMIT_NO_REF dt_ref ';'
 		{
-			struct node *target = get_node_by_ref($1, $3);
+			node_t *target = get_node_by_ref($1, $3);
 
 			if (target)
 				omit_node_if_unused(target);
@@ -321,7 +322,7 @@ propdata:
 	| propdataprefix DT_INCBIN '(' DT_STRING ',' integer_prim ',' integer_prim ')'
 		{
 			FILE *f = srcfile_relative_open($4.val, NULL);
-			struct data d;
+			data_t d;
 
 			if ($6 != 0)
 				if (fseek(f, $6, SEEK_SET) != 0)
@@ -337,7 +338,7 @@ propdata:
 	| propdataprefix DT_INCBIN '(' DT_STRING ')'
 		{
 			FILE *f = srcfile_relative_open($4.val, NULL);
-			struct data d = empty_data;
+			data_t d = empty_data;
 
 			d = data_copy_file(f, -1);
 
@@ -588,7 +589,7 @@ subnode:
 
 %%
 
-void yyerror(char const *s)
+void yyerror(dt_info_t *dti, bool *treesource_error, char const *s)
 {
 	ERROR(&yylloc, "%s", s);
 }

--- a/flattree.c
+++ b/flattree.c
@@ -36,22 +36,22 @@ struct emitter {
 	void (*cell)(void *, cell_t);
 	void (*string)(void *, const char *, int);
 	void (*align)(void *, int);
-	void (*data)(void *, struct data);
-	void (*beginnode)(void *, struct label *labels);
-	void (*endnode)(void *, struct label *labels);
-	void (*property)(void *, struct label *labels);
+	void (*data)(void *, data_t);
+	void (*beginnode)(void *, label_t *labels);
+	void (*endnode)(void *, label_t *labels);
+	void (*property)(void *, label_t *labels);
 };
 
 static void bin_emit_cell(void *e, cell_t val)
 {
-	struct data *dtbuf = e;
+	data_t *dtbuf = e;
 
 	*dtbuf = data_append_cell(*dtbuf, val);
 }
 
 static void bin_emit_string(void *e, const char *str, int len)
 {
-	struct data *dtbuf = e;
+	data_t *dtbuf = e;
 
 	if (len == 0)
 		len = strlen(str);
@@ -62,29 +62,29 @@ static void bin_emit_string(void *e, const char *str, int len)
 
 static void bin_emit_align(void *e, int a)
 {
-	struct data *dtbuf = e;
+	data_t *dtbuf = e;
 
 	*dtbuf = data_append_align(*dtbuf, a);
 }
 
-static void bin_emit_data(void *e, struct data d)
+static void bin_emit_data(void *e, data_t d)
 {
-	struct data *dtbuf = e;
+	data_t *dtbuf = e;
 
 	*dtbuf = data_append_data(*dtbuf, d.val, d.len);
 }
 
-static void bin_emit_beginnode(void *e, struct label *labels)
+static void bin_emit_beginnode(void *e, label_t *labels)
 {
 	bin_emit_cell(e, FDT_BEGIN_NODE);
 }
 
-static void bin_emit_endnode(void *e, struct label *labels)
+static void bin_emit_endnode(void *e, label_t *labels)
 {
 	bin_emit_cell(e, FDT_END_NODE);
 }
 
-static void bin_emit_property(void *e, struct label *labels)
+static void bin_emit_property(void *e, label_t *labels)
 {
 	bin_emit_cell(e, FDT_PROP);
 }
@@ -147,11 +147,11 @@ static void asm_emit_align(void *e, int a)
 	fprintf(f, "\t.balign\t%d, 0\n", a);
 }
 
-static void asm_emit_data(void *e, struct data d)
+static void asm_emit_data(void *e, data_t d)
 {
 	FILE *f = e;
 	unsigned int off = 0;
-	marker_handle_t m = d.markers;
+	marker_t *m = d.markers;
 
 	for_each_marker_of_type(m, LABEL)
 		emit_offset_label(f, m->ref, m->offset);
@@ -169,10 +169,10 @@ static void asm_emit_data(void *e, struct data d)
 	assert(off == d.len);
 }
 
-static void asm_emit_beginnode(void *e, struct label *labels)
+static void asm_emit_beginnode(void *e, label_t *labels)
 {
 	FILE *f = e;
-	struct label *l;
+	label_t *l;
 
 	for_each_label(labels, l) {
 		fprintf(f, "\t.globl\t%s\n", l->label);
@@ -182,10 +182,10 @@ static void asm_emit_beginnode(void *e, struct label *labels)
 	asm_emit_cell(e, FDT_BEGIN_NODE);
 }
 
-static void asm_emit_endnode(void *e, struct label *labels)
+static void asm_emit_endnode(void *e, label_t *labels)
 {
 	FILE *f = e;
-	struct label *l;
+	label_t *l;
 
 	fprintf(f, "\t/* FDT_END_NODE */\n");
 	asm_emit_cell(e, FDT_END_NODE);
@@ -195,10 +195,10 @@ static void asm_emit_endnode(void *e, struct label *labels)
 	}
 }
 
-static void asm_emit_property(void *e, struct label *labels)
+static void asm_emit_property(void *e, label_t *labels)
 {
 	FILE *f = e;
-	struct label *l;
+	label_t *l;
 
 	for_each_label(labels, l) {
 		fprintf(f, "\t.globl\t%s\n", l->label);
@@ -218,7 +218,7 @@ static struct emitter asm_emitter = {
 	.property = asm_emit_property,
 };
 
-static int stringtable_insert(struct data *d, const char *str)
+static int stringtable_insert(data_t *d, const char *str)
 {
 	unsigned int i;
 
@@ -233,12 +233,12 @@ static int stringtable_insert(struct data *d, const char *str)
 	return i;
 }
 
-static void flatten_tree(struct node *tree, struct emitter *emit,
-			 void *etarget, struct data *strbuf,
+static void flatten_tree(node_t *tree, struct emitter *emit,
+			 void *etarget, data_t *strbuf,
 			 struct version_info *vi)
 {
-	struct property *prop;
-	struct node *child;
+	property_t *prop;
+	node_t *child;
 	bool seen_name_prop = false;
 
 	if (tree->deleted)
@@ -291,11 +291,11 @@ static void flatten_tree(struct node *tree, struct emitter *emit,
 	emit->endnode(etarget, tree->labels);
 }
 
-static struct data flatten_reserve_list(struct reserve_info *reservelist,
-				 struct version_info *vi, dtc_options_handle_t options)
+static data_t flatten_reserve_list(reserve_info_t *reservelist,
+				 struct version_info *vi, unsigned int reservenum)
 {
-	struct reserve_info *re;
-	struct data d = empty_data;
+	reserve_info_t *re;
+	data_t d = empty_data;
 	unsigned int j;
 
 	for (re = reservelist; re; re = re->next) {
@@ -304,7 +304,7 @@ static struct data flatten_reserve_list(struct reserve_info *reservelist,
 	/*
 	 * Add additional reserved slots if the user asked for them.
 	 */
-	for (j = 0; j < options->reservenum; j++) {
+	for (j = 0; j < reservenum; j++) {
 		d = data_append_re(d, 0, 0);
 	}
 
@@ -343,14 +343,14 @@ static void make_fdt_header(struct fdt_header *fdt,
 		fdt->size_dt_struct = cpu_to_fdt32(dtsize);
 }
 
-void dt_to_blob(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t options)
+void dt_to_blob(FILE *f, dt_info_t *dti, int version)
 {
 	struct version_info *vi = NULL;
 	unsigned int i;
-	struct data blob       = empty_data;
-	struct data reservebuf = empty_data;
-	struct data dtbuf      = empty_data;
-	struct data strbuf     = empty_data;
+	data_t blob       = empty_data;
+	data_t reservebuf = empty_data;
+	data_t dtbuf      = empty_data;
+	data_t strbuf     = empty_data;
 	struct fdt_header fdt;
 	int padlen = 0;
 
@@ -364,7 +364,7 @@ void dt_to_blob(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t 
 	flatten_tree(dti->dt, &bin_emitter, &dtbuf, &strbuf, vi);
 	bin_emit_cell(&dtbuf, FDT_END);
 
-	reservebuf = flatten_reserve_list(dti->reservelist, vi, options);
+	reservebuf = flatten_reserve_list(dti->reservelist, vi, dti->options.reservenum);
 
 	/* Make header */
 	make_fdt_header(&fdt, vi, reservebuf.len, dtbuf.len, strbuf.len,
@@ -373,22 +373,22 @@ void dt_to_blob(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t 
 	/*
 	 * If the user asked for more space than is used, adjust the totalsize.
 	 */
-	if (options->minsize > 0) {
-		padlen = options->minsize - fdt32_to_cpu(fdt.totalsize);
+	if (dti->options.minsize > 0) {
+		padlen = dti->options.minsize - fdt32_to_cpu(fdt.totalsize);
 		if (padlen < 0) {
 			padlen = 0;
-			if (options->quiet < 1)
+			if (dti->options.quiet < 1)
 				fprintf(stderr,
 					"Warning: blob size %"PRIu32" >= minimum size %d\n",
-					fdt32_to_cpu(fdt.totalsize), options->minsize);
+					fdt32_to_cpu(fdt.totalsize), dti->options.minsize);
 		}
 	}
 
-	if (options->padsize > 0)
-		padlen = options->padsize;
+	if (dti->options.padsize > 0)
+		padlen = dti->options.padsize;
 
-	if (options->alignsize > 0)
-		padlen = ALIGN(fdt32_to_cpu(fdt.totalsize) + padlen, options->alignsize)
+	if (dti->options.alignsize > 0)
+		padlen = ALIGN(fdt32_to_cpu(fdt.totalsize) + padlen, dti->options.alignsize)
 			- fdt32_to_cpu(fdt.totalsize);
 
 	if (padlen > 0) {
@@ -430,7 +430,7 @@ void dt_to_blob(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t 
 	data_free(blob);
 }
 
-static void dump_stringtable_asm(FILE *f, struct data strbuf)
+static void dump_stringtable_asm(FILE *f, data_t strbuf)
 {
 	const char *p;
 	int len;
@@ -444,12 +444,12 @@ static void dump_stringtable_asm(FILE *f, struct data strbuf)
 	}
 }
 
-void dt_to_asm(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t options)
+void dt_to_asm(FILE *f, dt_info_t *dti, int version)
 {
 	struct version_info *vi = NULL;
 	unsigned int i;
-	struct data strbuf = empty_data;
-	struct reserve_info *re;
+	data_t strbuf = empty_data;
+	reserve_info_t *re;
 	const char *symprefix = "dt";
 
 	for (i = 0; i < ARRAY_SIZE(version_table); i++) {
@@ -515,7 +515,7 @@ void dt_to_asm(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t o
 	 * as it appears .quad isn't available in some assemblers.
 	 */
 	for (re = dti->reservelist; re; re = re->next) {
-		struct label *l;
+		label_t *l;
 
 		for_each_label(re->labels, l) {
 			fprintf(f, "\t.globl\t%s\n", l->label);
@@ -527,7 +527,7 @@ void dt_to_asm(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t o
 		ASM_EMIT_BELONG(f, "0x%08x", (unsigned int)(re->size >> 32));
 		ASM_EMIT_BELONG(f, "0x%08x", (unsigned int)(re->size & 0xffffffff));
 	}
-	for (i = 0; i < options->reservenum; i++) {
+	for (i = 0; i < dti->options.reservenum; i++) {
 		fprintf(f, "\t.long\t0, 0\n\t.long\t0, 0\n");
 	}
 
@@ -549,15 +549,15 @@ void dt_to_asm(FILE *f, struct dt_info *dti, int version, dtc_options_handle_t o
 	/*
 	 * If the user asked for more space than is used, pad it out.
 	 */
-	if (options->minsize > 0) {
+	if (dti->options.minsize > 0) {
 		fprintf(f, "\t.space\t%d - (_%s_blob_end - _%s_blob_start), 0\n",
-			options->minsize, symprefix, symprefix);
+			dti->options.minsize, symprefix, symprefix);
 	}
-	if (options->padsize > 0) {
-		fprintf(f, "\t.space\t%d, 0\n", options->padsize);
+	if (dti->options.padsize > 0) {
+		fprintf(f, "\t.space\t%d, 0\n", dti->options.padsize);
 	}
-	if (options->alignsize > 0)
-		asm_emit_align(f, options->alignsize);
+	if (dti->options.alignsize > 0)
+		asm_emit_align(f, dti->options.alignsize);
 	emit_label(f, symprefix, "blob_abs_end");
 
 	data_free(strbuf);
@@ -625,9 +625,9 @@ static char *flat_read_string(struct inbuf *inb)
 	return str;
 }
 
-static struct data flat_read_data(struct inbuf *inb, int len)
+static data_t flat_read_data(struct inbuf *inb, int len)
 {
-	struct data d = empty_data;
+	data_t d = empty_data;
 
 	if (len == 0)
 		return empty_data;
@@ -661,12 +661,12 @@ static char *flat_read_stringtable(struct inbuf *inb, int offset)
 	return xstrdup(inb->base + offset);
 }
 
-static struct property *flat_read_property(struct inbuf *dtbuf,
+static property_t *flat_read_property(struct inbuf *dtbuf,
 					   struct inbuf *strbuf, int flags)
 {
 	uint32_t proplen, stroff;
 	char *name;
-	struct data val;
+	data_t val;
 
 	proplen = flat_read_word(dtbuf);
 	stroff = flat_read_word(dtbuf);
@@ -682,10 +682,10 @@ static struct property *flat_read_property(struct inbuf *dtbuf,
 }
 
 
-static struct reserve_info *flat_read_mem_reserve(struct inbuf *inb)
+static reserve_info_t *flat_read_mem_reserve(struct inbuf *inb)
 {
-	struct reserve_info *reservelist = NULL;
-	struct reserve_info *new;
+	reserve_info_t *reservelist = NULL;
+	reserve_info_t *new;
 	struct fdt_reserve_entry re;
 
 	/*
@@ -728,11 +728,11 @@ static char *nodename_from_path(const char *ppath, const char *cpath)
 	return xstrdup(cpath + plen);
 }
 
-static struct node *unflatten_tree(struct inbuf *dtbuf,
+static node_t *unflatten_tree(struct inbuf *dtbuf,
 				   struct inbuf *strbuf,
 				   const char *parent_flatname, int flags)
 {
-	struct node *node;
+	node_t *node;
 	char *flatname;
 	uint32_t val;
 
@@ -746,8 +746,8 @@ static struct node *unflatten_tree(struct inbuf *dtbuf,
 		node->name = flatname;
 
 	do {
-		struct property *prop;
-		struct node *child;
+		property_t *prop;
+		node_t *child;
 
 		val = flat_read_word(dtbuf);
 		switch (val) {
@@ -793,8 +793,11 @@ static struct node *unflatten_tree(struct inbuf *dtbuf,
 }
 
 
-struct dt_info *dt_from_blob(const char *fname)
+void dt_from_blob(const char *fname, dt_info_t *dti)
 {
+	if (dti == NULL)
+		die("Attempted to construct tree using a null pointer");
+
 	FILE *f;
 	fdt32_t magic_buf, totalsize_buf;
 	uint32_t magic, totalsize, version, size_dt, boot_cpuid_phys;
@@ -806,8 +809,8 @@ struct dt_info *dt_from_blob(const char *fname)
 	struct inbuf dtbuf, strbuf;
 	struct inbuf memresvbuf;
 	int sizeleft;
-	struct reserve_info *reservelist;
-	struct node *tree;
+	reserve_info_t *reservelist;
+	node_t *tree;
 	uint32_t val;
 	int flags = 0;
 
@@ -922,5 +925,5 @@ struct dt_info *dt_from_blob(const char *fname)
 
 	fclose(f);
 
-	return build_dt_info(DTSF_V1, reservelist, tree, boot_cpuid_phys);
+	build_dt_info(dti, DTSF_V1, reservelist, tree, boot_cpuid_phys);
 }

--- a/fstree.c
+++ b/fstree.c
@@ -8,12 +8,12 @@
 #include <dirent.h>
 #include <sys/stat.h>
 
-static struct node *read_fstree(const char *dirname)
+static node_t *read_fstree(const char *dirname)
 {
 	DIR *d;
 	struct dirent *de;
 	struct stat st;
-	struct node *tree;
+	node_t *tree;
 
 	d = opendir(dirname);
 	if (!d)
@@ -34,7 +34,7 @@ static struct node *read_fstree(const char *dirname)
 			die("stat(%s): %s\n", tmpname, strerror(errno));
 
 		if (S_ISREG(st.st_mode)) {
-			struct property *prop;
+			property_t *prop;
 			FILE *pfile;
 
 			pfile = fopen(tmpname, "rb");
@@ -51,7 +51,7 @@ static struct node *read_fstree(const char *dirname)
 				fclose(pfile);
 			}
 		} else if (S_ISDIR(st.st_mode)) {
-			struct node *newchild;
+			node_t *newchild;
 
 			newchild = read_fstree(tmpname);
 			newchild = name_node(newchild, xstrdup(de->d_name));
@@ -65,12 +65,15 @@ static struct node *read_fstree(const char *dirname)
 	return tree;
 }
 
-struct dt_info *dt_from_fs(const char *dirname)
+void dt_from_fs(const char *dirname, dt_info_t *dti)
 {
-	struct node *tree;
+	if (dti == NULL)
+		die("Attempted to construct tree using a null pointer");
+
+	node_t *tree;
 
 	tree = read_fstree(dirname);
 	tree = name_node(tree, "");
 
-	return build_dt_info(DTSF_V1, NULL, tree, guess_boot_cpuid(tree));
+	build_dt_info(dti, DTSF_V1, NULL, tree, guess_boot_cpuid(tree));
 }

--- a/libdtc.c
+++ b/libdtc.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *
+*/
+
+#include <sys/stat.h>
+
+#include "dtc.h"
+#include "srcpos.h"
+
+
+static int is_power_of_2(int x)
+{
+	return (x > 0) && ((x & (x - 1)) == 0);
+}
+
+static void fill_fullpaths(struct node *tree, const char *prefix)
+{
+	struct node *child;
+	const char *unit;
+
+	tree->fullpath = join_path(prefix, tree->name);
+
+	unit = strchr(tree->name, '@');
+	if (unit)
+		tree->basenamelen = unit - tree->name;
+	else
+		tree->basenamelen = strlen(tree->name);
+
+	for_each_child(tree, child)
+		fill_fullpaths(child, tree->fullpath);
+}
+
+static const char *guess_type_by_name(const char *fname, const char *fallback)
+{
+	const char *s;
+
+	s = strrchr(fname, '.');
+	if (s == NULL)
+		return fallback;
+	if (!strcasecmp(s, ".dts"))
+		return "dts";
+	if (!strcasecmp(s, ".yaml"))
+		return "yaml";
+	if (!strcasecmp(s, ".dtbo"))
+		return "dtb";
+	if (!strcasecmp(s, ".dtb"))
+		return "dtb";
+	return fallback;
+}
+
+static const char *guess_input_format(const char *fname, const char *fallback)
+{
+	struct stat statbuf;
+	fdt32_t magic;
+	FILE *f;
+
+	if (stat(fname, &statbuf) != 0)
+		return fallback;
+
+	if (S_ISDIR(statbuf.st_mode))
+		return "fs";
+
+	if (!S_ISREG(statbuf.st_mode))
+		return fallback;
+
+	f = fopen(fname, "r");
+	if (f == NULL)
+		return fallback;
+	if (fread(&magic, 4, 1, f) != 1) {
+		fclose(f);
+		return fallback;
+	}
+	fclose(f);
+
+	if (fdt32_to_cpu(magic) == FDT_MAGIC)
+		return "dtb";
+
+	return guess_type_by_name(fname, fallback);
+}
+
+

--- a/livetree.c
+++ b/livetree.c
@@ -10,9 +10,9 @@
  * Tree building functions
  */
 
-void add_label(struct label **labels, char *label)
+void add_label(label_t **labels, char *label)
 {
-	struct label *new;
+	label_t *new;
 
 	/* Make sure the label isn't already there */
 	for_each_label_withdel(*labels, new)
@@ -28,18 +28,18 @@ void add_label(struct label **labels, char *label)
 	*labels = new;
 }
 
-void delete_labels(struct label **labels)
+void delete_labels(label_t **labels)
 {
-	struct label *label;
+	label_t *label;
 
 	for_each_label(*labels, label)
 		label->deleted = 1;
 }
 
-struct property *build_property(char *name, struct data val,
-				struct srcpos *srcpos)
+property_t *build_property(char *name, data_t val,
+				srcpos_t *srcpos)
 {
-	struct property *new = xmalloc(sizeof(*new));
+	property_t *new = xmalloc(sizeof(*new));
 
 	memset(new, 0, sizeof(*new));
 
@@ -50,9 +50,9 @@ struct property *build_property(char *name, struct data val,
 	return new;
 }
 
-struct property *build_property_delete(char *name)
+property_t *build_property_delete(char *name)
 {
-	struct property *new = xmalloc(sizeof(*new));
+	property_t *new = xmalloc(sizeof(*new));
 
 	memset(new, 0, sizeof(*new));
 
@@ -62,7 +62,7 @@ struct property *build_property_delete(char *name)
 	return new;
 }
 
-struct property *chain_property(struct property *first, struct property *list)
+property_t *chain_property(property_t *first, property_t *list)
 {
 	assert(first->next == NULL);
 
@@ -70,11 +70,11 @@ struct property *chain_property(struct property *first, struct property *list)
 	return first;
 }
 
-struct property *reverse_properties(struct property *first)
+property_t *reverse_properties(property_t *first)
 {
-	struct property *p = first;
-	struct property *head = NULL;
-	struct property *next;
+	property_t *p = first;
+	property_t *head = NULL;
+	property_t *next;
 
 	while (p) {
 		next = p->next;
@@ -85,11 +85,11 @@ struct property *reverse_properties(struct property *first)
 	return head;
 }
 
-struct node *build_node(struct property *proplist, struct node *children,
-			struct srcpos *srcpos)
+node_t *build_node(property_t *proplist, node_t *children,
+			srcpos_t *srcpos)
 {
-	struct node *new = xmalloc(sizeof(*new));
-	struct node *child;
+	node_t *new = xmalloc(sizeof(*new));
+	node_t *child;
 
 	memset(new, 0, sizeof(*new));
 
@@ -104,9 +104,9 @@ struct node *build_node(struct property *proplist, struct node *children,
 	return new;
 }
 
-struct node *build_node_delete(struct srcpos *srcpos)
+node_t *build_node_delete(srcpos_t *srcpos)
 {
-	struct node *new = xmalloc(sizeof(*new));
+	node_t *new = xmalloc(sizeof(*new));
 
 	memset(new, 0, sizeof(*new));
 
@@ -116,7 +116,7 @@ struct node *build_node_delete(struct srcpos *srcpos)
 	return new;
 }
 
-struct node *name_node(struct node *node, char *name)
+node_t *name_node(node_t *node, char *name)
 {
 	assert(node->name == NULL);
 
@@ -125,25 +125,25 @@ struct node *name_node(struct node *node, char *name)
 	return node;
 }
 
-struct node *omit_node_if_unused(struct node *node)
+node_t *omit_node_if_unused(node_t *node)
 {
 	node->omit_if_unused = 1;
 
 	return node;
 }
 
-struct node *reference_node(struct node *node)
+node_t *reference_node(node_t *node)
 {
 	node->is_referenced = 1;
 
 	return node;
 }
 
-struct node *merge_nodes(struct node *old_node, struct node *new_node)
+node_t *merge_nodes(node_t *old_node, node_t *new_node)
 {
-	struct property *new_prop, *old_prop;
-	struct node *new_child, *old_child;
-	struct label *l;
+	property_t *new_prop, *old_prop;
+	node_t *new_child, *old_child;
+	label_t *l;
 
 	old_node->deleted = 0;
 
@@ -225,12 +225,12 @@ struct node *merge_nodes(struct node *old_node, struct node *new_node)
 	return old_node;
 }
 
-struct node * add_orphan_node(struct node *dt, struct node *new_node, char *ref)
+node_t * add_orphan_node(node_t *dt, node_t *new_node, char *ref)
 {
 	static unsigned int next_orphan_fragment = 0;
-	struct node *node;
-	struct property *p;
-	struct data d = empty_data;
+	node_t *node;
+	property_t *p;
+	data_t d = empty_data;
 	char *name;
 
 	if (ref[0] == '/') {
@@ -255,7 +255,7 @@ struct node * add_orphan_node(struct node *dt, struct node *new_node, char *ref)
 	return dt;
 }
 
-struct node *chain_node(struct node *first, struct node *list)
+node_t *chain_node(node_t *first, node_t *list)
 {
 	assert(first->next_sibling == NULL);
 
@@ -263,9 +263,9 @@ struct node *chain_node(struct node *first, struct node *list)
 	return first;
 }
 
-void add_property(struct node *node, struct property *prop)
+void add_property(node_t *node, property_t *prop)
 {
-	struct property **p;
+	property_t **p;
 
 	prop->next = NULL;
 
@@ -276,9 +276,9 @@ void add_property(struct node *node, struct property *prop)
 	*p = prop;
 }
 
-void delete_property_by_name(struct node *node, char *name)
+void delete_property_by_name(node_t *node, char *name)
 {
-	struct property *prop = node->proplist;
+	property_t *prop = node->proplist;
 
 	while (prop) {
 		if (streq(prop->name, name)) {
@@ -289,15 +289,15 @@ void delete_property_by_name(struct node *node, char *name)
 	}
 }
 
-void delete_property(struct property *prop)
+void delete_property(property_t *prop)
 {
 	prop->deleted = 1;
 	delete_labels(&prop->labels);
 }
 
-void add_child(struct node *parent, struct node *child)
+void add_child(node_t *parent, node_t *child)
 {
-	struct node **p;
+	node_t **p;
 
 	child->next_sibling = NULL;
 	child->parent = parent;
@@ -309,9 +309,9 @@ void add_child(struct node *parent, struct node *child)
 	*p = child;
 }
 
-void delete_node_by_name(struct node *parent, char *name)
+void delete_node_by_name(node_t *parent, char *name)
 {
-	struct node *node = parent->children;
+	node_t *node = parent->children;
 
 	while (node) {
 		if (streq(node->name, name)) {
@@ -322,10 +322,10 @@ void delete_node_by_name(struct node *parent, char *name)
 	}
 }
 
-void delete_node(struct node *node)
+void delete_node(node_t *node)
 {
-	struct property *prop;
-	struct node *child;
+	property_t *prop;
+	node_t *child;
 
 	node->deleted = 1;
 	for_each_child(node, child)
@@ -335,12 +335,12 @@ void delete_node(struct node *node)
 	delete_labels(&node->labels);
 }
 
-void append_to_property(struct node *node,
+void append_to_property(node_t *node,
 			char *name, const void *data, int len,
 			enum markertype type)
 {
-	struct data d;
-	struct property *p;
+	data_t d;
+	property_t *p;
 
 	p = get_property(node, name);
 	if (p) {
@@ -355,9 +355,9 @@ void append_to_property(struct node *node,
 	}
 }
 
-struct reserve_info *build_reserve_entry(uint64_t address, uint64_t size)
+reserve_info_t *build_reserve_entry(uint64_t address, uint64_t size)
 {
-	struct reserve_info *new = xmalloc(sizeof(*new));
+	reserve_info_t *new = xmalloc(sizeof(*new));
 
 	memset(new, 0, sizeof(*new));
 
@@ -367,8 +367,8 @@ struct reserve_info *build_reserve_entry(uint64_t address, uint64_t size)
 	return new;
 }
 
-struct reserve_info *chain_reserve_entry(struct reserve_info *first,
-					struct reserve_info *list)
+reserve_info_t *chain_reserve_entry(reserve_info_t *first,
+					reserve_info_t *list)
 {
 	assert(first->next == NULL);
 
@@ -376,10 +376,10 @@ struct reserve_info *chain_reserve_entry(struct reserve_info *first,
 	return first;
 }
 
-struct reserve_info *add_reserve_entry(struct reserve_info *list,
-				      struct reserve_info *new)
+reserve_info_t *add_reserve_entry(reserve_info_t *list,
+				      reserve_info_t *new)
 {
-	struct reserve_info *last;
+	reserve_info_t *last;
 
 	new->next = NULL;
 
@@ -394,26 +394,22 @@ struct reserve_info *add_reserve_entry(struct reserve_info *list,
 	return list;
 }
 
-struct dt_info *build_dt_info(unsigned int dtsflags,
-			      struct reserve_info *reservelist,
-			      struct node *tree, uint32_t boot_cpuid_phys)
+void build_dt_info(dt_info_t *dti,
+				  unsigned int dtsflags,
+			      reserve_info_t *reservelist,
+			      node_t *tree, uint32_t boot_cpuid_phys)
 {
-	struct dt_info *dti;
-
-	dti = xmalloc(sizeof(*dti));
 	dti->dtsflags = dtsflags;
 	dti->reservelist = reservelist;
 	dti->dt = tree;
 	dti->boot_cpuid_phys = boot_cpuid_phys;
-
-	return dti;
 }
 
 /*
  * Tree accessor functions
  */
 
-const char *get_unitname(struct node *node)
+const char *get_unitname(node_t *node)
 {
 	if (node->name[node->basenamelen] == '\0')
 		return "";
@@ -421,9 +417,9 @@ const char *get_unitname(struct node *node)
 		return node->name + node->basenamelen + 1;
 }
 
-struct property *get_property(struct node *node, const char *propname)
+property_t *get_property(node_t *node, const char *propname)
 {
-	struct property *prop;
+	property_t *prop;
 
 	for_each_property(node, prop)
 		if (streq(prop->name, propname))
@@ -432,28 +428,28 @@ struct property *get_property(struct node *node, const char *propname)
 	return NULL;
 }
 
-cell_t propval_cell(struct property *prop)
+cell_t propval_cell(property_t *prop)
 {
 	assert(prop->val.len == sizeof(cell_t));
 	return fdt32_to_cpu(*((fdt32_t *)prop->val.val));
 }
 
-cell_t propval_cell_n(struct property *prop, unsigned int n)
+cell_t propval_cell_n(property_t *prop, unsigned int n)
 {
 	assert(prop->val.len / sizeof(cell_t) >= n);
 	return fdt32_to_cpu(*((fdt32_t *)prop->val.val + n));
 }
 
-struct property *get_property_by_label(struct node *tree, const char *label,
-				       struct node **node)
+property_t *get_property_by_label(node_t *tree, const char *label,
+				       node_t **node)
 {
-	struct property *prop;
-	struct node *c;
+	property_t *prop;
+	node_t *c;
 
 	*node = tree;
 
 	for_each_property(tree, prop) {
-		struct label *l;
+		label_t *l;
 
 		for_each_label(prop->labels, l)
 			if (streq(l->label, label))
@@ -470,12 +466,12 @@ struct property *get_property_by_label(struct node *tree, const char *label,
 	return NULL;
 }
 
-marker_handle_t get_marker_label(struct node *tree, const char *label,
-				struct node **node, struct property **prop)
+marker_t *get_marker_label(node_t *tree, const char *label,
+				node_t **node, property_t **prop)
 {
-	marker_handle_t m;
-	struct property *p;
-	struct node *c;
+	marker_t *m;
+	property_t *p;
+	node_t *c;
 
 	*node = tree;
 
@@ -498,9 +494,9 @@ marker_handle_t get_marker_label(struct node *tree, const char *label,
 	return NULL;
 }
 
-struct node *get_subnode(struct node *node, const char *nodename)
+node_t *get_subnode(node_t *node, const char *nodename)
 {
-	struct node *child;
+	node_t *child;
 
 	for_each_child(node, child)
 		if (streq(child->name, nodename))
@@ -509,10 +505,10 @@ struct node *get_subnode(struct node *node, const char *nodename)
 	return NULL;
 }
 
-struct node *get_node_by_path(struct node *tree, const char *path)
+node_t *get_node_by_path(node_t *tree, const char *path)
 {
 	const char *p;
-	struct node *child;
+	node_t *child;
 
 	if (!path || ! (*path)) {
 		if (tree->deleted)
@@ -535,10 +531,10 @@ struct node *get_node_by_path(struct node *tree, const char *path)
 	return NULL;
 }
 
-struct node *get_node_by_label(struct node *tree, const char *label)
+node_t *get_node_by_label(node_t *tree, const char *label)
 {
-	struct node *child, *node;
-	struct label *l;
+	node_t *child, *node;
+	label_t *l;
 
 	assert(label && (strlen(label) > 0));
 
@@ -555,12 +551,12 @@ struct node *get_node_by_label(struct node *tree, const char *label)
 	return NULL;
 }
 
-struct node *get_node_by_phandle(struct node *tree, cell_t phandle, dtc_options_handle_t options)
+node_t *get_node_by_phandle(node_t *tree, cell_t phandle, int generate_fixups)
 {
-	struct node *child, *node;
+	node_t *child, *node;
 
 	if (!phandle_is_valid(phandle)) {
-		assert(options->generate_fixups);
+		assert(generate_fixups);
 		return NULL;
 	}
 
@@ -571,7 +567,7 @@ struct node *get_node_by_phandle(struct node *tree, cell_t phandle, dtc_options_
 	}
 
 	for_each_child(tree, child) {
-		node = get_node_by_phandle(child, phandle, options);
+		node = get_node_by_phandle(child, phandle, generate_fixups);
 		if (node)
 			return node;
 	}
@@ -579,9 +575,9 @@ struct node *get_node_by_phandle(struct node *tree, cell_t phandle, dtc_options_
 	return NULL;
 }
 
-struct node *get_node_by_ref(struct node *tree, const char *ref)
+node_t *get_node_by_ref(node_t *tree, const char *ref)
 {
-	struct node *target = tree;
+	node_t *target = tree;
 	const char *label = NULL, *path = NULL;
 
 	if (streq(ref, "/"))
@@ -616,15 +612,15 @@ struct node *get_node_by_ref(struct node *tree, const char *ref)
 	return target;
 }
 
-cell_t get_node_phandle(struct node *root, struct node *node, dtc_options_handle_t options)
+cell_t get_node_phandle(node_t *root, node_t *node, int phandle_format)
 {
 	static cell_t phandle = 1; /* FIXME: ick, static local */
-	struct data d = empty_data;
+	data_t d = empty_data;
 
 	if (phandle_is_valid(node->phandle))
 		return node->phandle;
 
-	while (get_node_by_phandle(root, phandle, options))
+	while (get_node_by_phandle(root, phandle, phandle_format))
 		phandle++;
 
 	node->phandle = phandle;
@@ -633,11 +629,11 @@ cell_t get_node_phandle(struct node *root, struct node *node, dtc_options_handle
 	d = data_append_cell(d, phandle);
 
 	if (!get_property(node, "linux,phandle")
-	    && (options->phandle_format & PHANDLE_LEGACY))
+	    && (phandle_format & PHANDLE_LEGACY))
 		add_property(node, build_property("linux,phandle", d, NULL));
 
 	if (!get_property(node, "phandle")
-	    && (options->phandle_format & PHANDLE_EPAPR))
+	    && (phandle_format & PHANDLE_EPAPR))
 		add_property(node, build_property("phandle", d, NULL));
 
 	/* If the node *does* have a phandle property, we must
@@ -647,10 +643,10 @@ cell_t get_node_phandle(struct node *root, struct node *node, dtc_options_handle
 	return node->phandle;
 }
 
-uint32_t guess_boot_cpuid(struct node *tree)
+uint32_t guess_boot_cpuid(node_t *tree)
 {
-	struct node *cpus, *bootcpu;
-	struct property *reg;
+	node_t *cpus, *bootcpu;
+	property_t *reg;
 
 	cpus = get_node_by_path(tree, "/cpus");
 	if (!cpus)
@@ -672,10 +668,10 @@ uint32_t guess_boot_cpuid(struct node *tree)
 
 static int cmp_reserve_info(const void *ax, const void *bx)
 {
-	const struct reserve_info *a, *b;
+	const reserve_info_t *a, *b;
 
-	a = *((const struct reserve_info * const *)ax);
-	b = *((const struct reserve_info * const *)bx);
+	a = *((const reserve_info_t * const *)ax);
+	b = *((const reserve_info_t * const *)bx);
 
 	if (a->address < b->address)
 		return -1;
@@ -689,9 +685,9 @@ static int cmp_reserve_info(const void *ax, const void *bx)
 		return 0;
 }
 
-static void sort_reserve_entries(struct dt_info *dti)
+static void sort_reserve_entries(dt_info_t *dti)
 {
-	struct reserve_info *ri, **tbl;
+	reserve_info_t *ri, **tbl;
 	int n = 0, i = 0;
 
 	for (ri = dti->reservelist;
@@ -721,18 +717,18 @@ static void sort_reserve_entries(struct dt_info *dti)
 
 static int cmp_prop(const void *ax, const void *bx)
 {
-	const struct property *a, *b;
+	const property_t *a, *b;
 
-	a = *((const struct property * const *)ax);
-	b = *((const struct property * const *)bx);
+	a = *((const property_t * const *)ax);
+	b = *((const property_t * const *)bx);
 
 	return strcmp(a->name, b->name);
 }
 
-static void sort_properties(struct node *node)
+static void sort_properties(node_t *node)
 {
 	int n = 0, i = 0;
-	struct property *prop, **tbl;
+	property_t *prop, **tbl;
 
 	for_each_property_withdel(node, prop)
 		n++;
@@ -757,18 +753,18 @@ static void sort_properties(struct node *node)
 
 static int cmp_subnode(const void *ax, const void *bx)
 {
-	const struct node *a, *b;
+	const node_t *a, *b;
 
-	a = *((const struct node * const *)ax);
-	b = *((const struct node * const *)bx);
+	a = *((const node_t * const *)ax);
+	b = *((const node_t * const *)bx);
 
 	return strcmp(a->name, b->name);
 }
 
-static void sort_subnodes(struct node *node)
+static void sort_subnodes(node_t *node)
 {
 	int n = 0, i = 0;
-	struct node *subnode, **tbl;
+	node_t *subnode, **tbl;
 
 	for_each_child_withdel(node, subnode)
 		n++;
@@ -791,9 +787,9 @@ static void sort_subnodes(struct node *node)
 	free(tbl);
 }
 
-static void sort_node(struct node *node)
+static void sort_node(node_t *node)
 {
-	struct node *c;
+	node_t *c;
 
 	sort_properties(node);
 	sort_subnodes(node);
@@ -801,16 +797,16 @@ static void sort_node(struct node *node)
 		sort_node(c);
 }
 
-void sort_tree(struct dt_info *dti)
+void sort_tree(dt_info_t *dti)
 {
 	sort_reserve_entries(dti);
 	sort_node(dti->dt);
 }
 
 /* utility helper to avoid code duplication */
-static struct node *build_and_name_child_node(struct node *parent, char *name)
+static node_t *build_and_name_child_node(node_t *parent, char *name)
 {
-	struct node *node;
+	node_t *node;
 
 	node = build_node(NULL, NULL, NULL);
 	name_node(node, xstrdup(name));
@@ -819,9 +815,9 @@ static struct node *build_and_name_child_node(struct node *parent, char *name)
 	return node;
 }
 
-static struct node *build_root_node(struct node *dt, char *name)
+static node_t *build_root_node(node_t *dt, char *name)
 {
-	struct node *an;
+	node_t *an;
 
 	an = get_subnode(dt, name);
 	if (!an)
@@ -833,9 +829,9 @@ static struct node *build_root_node(struct node *dt, char *name)
 	return an;
 }
 
-static bool any_label_tree(struct dt_info *dti, struct node *node)
+static bool any_label_tree(dt_info_t *dti, node_t *node)
 {
-	struct node *c;
+	node_t *c;
 
 	if (node->labels)
 		return true;
@@ -847,15 +843,14 @@ static bool any_label_tree(struct dt_info *dti, struct node *node)
 	return false;
 }
 
-static void generate_label_tree_internal(struct dt_info *dti,
-					 struct node *an, struct node *node,
-					 dtc_options_handle_t options,
+static void generate_label_tree_internal(dt_info_t *dti,
+					 node_t *an, node_t *node,
 					 bool allocph)
 {
-	struct node *dt = dti->dt;
-	struct node *c;
-	struct property *p;
-	struct label *l;
+	node_t *dt = dti->dt;
+	node_t *c;
+	property_t *p;
+	label_t *l;
 
 	/* if there are labels */
 	if (node->labels) {
@@ -882,18 +877,18 @@ static void generate_label_tree_internal(struct dt_info *dti,
 
 		/* force allocation of a phandle for this node */
 		if (allocph)
-			(void)get_node_phandle(dt, node, options);
+			(void)get_node_phandle(dt, node, dti->options.phandle_format);
 	}
 
 	for_each_child(node, c)
-		generate_label_tree_internal(dti, an, c, options, allocph);
+		generate_label_tree_internal(dti, an, c, allocph);
 }
 
-static bool any_fixup_tree(struct dt_info *dti, struct node *node)
+static bool any_fixup_tree(dt_info_t *dti, node_t *node)
 {
-	struct node *c;
-	struct property *prop;
-	marker_handle_t m;
+	node_t *c;
+	property_t *prop;
+	marker_t *m;
 
 	for_each_property(node, prop) {
 		m = prop->val.markers;
@@ -911,9 +906,9 @@ static bool any_fixup_tree(struct dt_info *dti, struct node *node)
 	return false;
 }
 
-static void add_fixup_entry(struct dt_info *dti, struct node *fn,
-			    struct node *node, struct property *prop,
-			    marker_handle_t m)
+static void add_fixup_entry(dt_info_t *dti, node_t *fn,
+			    node_t *node, property_t *prop,
+			    marker_t *m)
 {
 	char *entry;
 
@@ -937,15 +932,15 @@ static void add_fixup_entry(struct dt_info *dti, struct node *fn,
 	free(entry);
 }
 
-static void generate_fixups_tree_internal(struct dt_info *dti,
-					  struct node *fn,
-					  struct node *node)
+static void generate_fixups_tree_internal(dt_info_t *dti,
+					  node_t *fn,
+					  node_t *node)
 {
-	struct node *dt = dti->dt;
-	struct node *c;
-	struct property *prop;
-	marker_handle_t m;
-	struct node *refnode;
+	node_t *dt = dti->dt;
+	node_t *c;
+	property_t *prop;
+	marker_t *m;
+	node_t *refnode;
 
 	for_each_property(node, prop) {
 		m = prop->val.markers;
@@ -960,11 +955,11 @@ static void generate_fixups_tree_internal(struct dt_info *dti,
 		generate_fixups_tree_internal(dti, fn, c);
 }
 
-static bool any_local_fixup_tree(struct dt_info *dti, struct node *node)
+static bool any_local_fixup_tree(dt_info_t *dti, node_t *node)
 {
-	struct node *c;
-	struct property *prop;
-	marker_handle_t m;
+	node_t *c;
+	property_t *prop;
+	marker_t *m;
 
 	for_each_property(node, prop) {
 		m = prop->val.markers;
@@ -982,12 +977,12 @@ static bool any_local_fixup_tree(struct dt_info *dti, struct node *node)
 	return false;
 }
 
-static void add_local_fixup_entry(struct dt_info *dti,
-		struct node *lfn, struct node *node,
-		struct property *prop, marker_handle_t m,
-		struct node *refnode)
+static void add_local_fixup_entry(dt_info_t *dti,
+		node_t *lfn, node_t *node,
+		property_t *prop, marker_t *m,
+		node_t *refnode)
 {
-	struct node *wn, *nwn;	/* local fixup node, walk node, new */
+	node_t *wn, *nwn;	/* local fixup node, walk node, new */
 	fdt32_t value_32;
 	char **compp;
 	int i, depth;
@@ -1018,15 +1013,15 @@ static void add_local_fixup_entry(struct dt_info *dti,
 	append_to_property(wn, prop->name, &value_32, sizeof(value_32), TYPE_UINT32);
 }
 
-static void generate_local_fixups_tree_internal(struct dt_info *dti,
-						struct node *lfn,
-						struct node *node)
+static void generate_local_fixups_tree_internal(dt_info_t *dti,
+						node_t *lfn,
+						node_t *node)
 {
-	struct node *dt = dti->dt;
-	struct node *c;
-	struct property *prop;
-	marker_handle_t m;
-	struct node *refnode;
+	node_t *dt = dti->dt;
+	node_t *c;
+	property_t *prop;
+	marker_t *m;
+	node_t *refnode;
 
 	for_each_property(node, prop) {
 		m = prop->val.markers;
@@ -1041,15 +1036,15 @@ static void generate_local_fixups_tree_internal(struct dt_info *dti,
 		generate_local_fixups_tree_internal(dti, lfn, c);
 }
 
-void generate_label_tree(struct dt_info *dti, char *name, dtc_options_handle_t options, bool allocph)
+void generate_label_tree(dt_info_t *dti, char *name, bool allocph)
 {
 	if (!any_label_tree(dti, dti->dt))
 		return;
 	generate_label_tree_internal(dti, build_root_node(dti->dt, name),
-				     dti->dt, options, allocph);
+				     dti->dt, allocph);
 }
 
-void generate_fixups_tree(struct dt_info *dti, char *name)
+void generate_fixups_tree(dt_info_t *dti, char *name)
 {
 	if (!any_fixup_tree(dti, dti->dt))
 		return;
@@ -1057,7 +1052,7 @@ void generate_fixups_tree(struct dt_info *dti, char *name)
 				      dti->dt);
 }
 
-void generate_local_fixups_tree(struct dt_info *dti, char *name)
+void generate_local_fixups_tree(dt_info_t *dti, char *name)
 {
 	if (!any_local_fixup_tree(dti, dti->dt))
 		return;

--- a/srcpos.h
+++ b/srcpos.h
@@ -10,16 +10,17 @@
 #include <stdbool.h>
 #include "util.h"
 
-struct srcfile_state {
+typedef struct srcfile_state_ srcfile_state_t;
+struct srcfile_state_ {
 	FILE *f;
 	char *name;
 	char *dir;
 	int lineno, colno;
-	struct srcfile_state *prev;
+	srcfile_state_t *prev;
 };
 
 extern FILE *depfile; /* = NULL */
-extern struct srcfile_state *current_srcfile; /* = NULL */
+extern srcfile_state_t *current_srcfile; /* = NULL */
 
 /**
  * Open a source file.
@@ -54,16 +55,17 @@ bool srcfile_pop(void);
  */
 void srcfile_add_search_path(const char *dirname);
 
+typedef struct srcpos srcpos_t;
 struct srcpos {
     int first_line;
     int first_column;
     int last_line;
     int last_column;
-    struct srcfile_state *file;
-    struct srcpos *next;
+    srcfile_state_t *file;
+    srcpos_t *next;
 };
 
-#define YYLTYPE struct srcpos
+#define YYLTYPE srcpos_t
 
 #define YYLLOC_DEFAULT(Current, Rhs, N)						\
 	do {									\
@@ -84,18 +86,18 @@ struct srcpos {
 	} while (0)
 
 
-extern void srcpos_update(struct srcpos *pos, const char *text, int len);
-extern struct srcpos *srcpos_copy(struct srcpos *pos);
-extern struct srcpos *srcpos_extend(struct srcpos *new_srcpos,
-				    struct srcpos *old_srcpos);
-extern char *srcpos_string(struct srcpos *pos);
-extern char *srcpos_string_first(struct srcpos *pos, int level);
-extern char *srcpos_string_last(struct srcpos *pos, int level);
+extern void srcpos_update(srcpos_t *pos, const char *text, int len);
+extern srcpos_t *srcpos_copy(srcpos_t *pos);
+extern srcpos_t *srcpos_extend(srcpos_t *new_srcpos,
+				    srcpos_t *old_srcpos);
+extern char *srcpos_string(srcpos_t *pos);
+extern char *srcpos_string_first(srcpos_t *pos, int level);
+extern char *srcpos_string_last(srcpos_t *pos, int level);
 
 
-extern void PRINTF(3, 0) srcpos_verror(struct srcpos *pos, const char *prefix,
+extern void PRINTF(3, 0) srcpos_verror(srcpos_t *pos, const char *prefix,
 					const char *fmt, va_list va);
-extern void PRINTF(3, 4) srcpos_error(struct srcpos *pos, const char *prefix,
+extern void PRINTF(3, 4) srcpos_error(srcpos_t *pos, const char *prefix,
 				      const char *fmt, ...);
 
 extern void srcpos_set_line(char *f, int l);

--- a/yamltree.c
+++ b/yamltree.c
@@ -29,7 +29,7 @@ char *yaml_error_name[] = {
 		    (emitter)->problem, __func__, __LINE__);		\
 })
 
-static void yaml_propval_int(yaml_emitter_t *emitter, marker_handle_t markers,
+static void yaml_propval_int(yaml_emitter_t *emitter, marker_t *markers,
 	char *data, unsigned int seq_offset, unsigned int len, int width)
 {
 	yaml_event_t event;
@@ -52,7 +52,7 @@ static void yaml_propval_int(yaml_emitter_t *emitter, marker_handle_t markers,
 
 	for (off = 0; off < len; off += width) {
 		char buf[32];
-		marker_handle_t m;
+		marker_t *m;
 		bool is_phandle = false;
 
 		switch(width) {
@@ -114,8 +114,8 @@ static void yaml_propval(yaml_emitter_t *emitter, struct property *prop)
 {
 	yaml_event_t event;
 	unsigned int len = prop->val.len;
-	marker_handle_t m = prop->val.markers;
-	marker_handle_t markers = prop->val.markers;
+	marker_t *m = prop->val.markers;
+	marker_t *markers = prop->val.markers;
 
 	/* Emit the property name */
 	yaml_scalar_event_initialize(&event, NULL,
@@ -204,7 +204,7 @@ static void yaml_tree(struct node *tree, yaml_emitter_t *emitter)
 	yaml_emitter_emit_or_die(emitter, &event);
 }
 
-void dt_to_yaml(FILE *f, struct dt_info *dti, dtc_options_handle_t options)
+void dt_to_yaml(FILE *f, struct dt_info *dti)
 {
 	yaml_emitter_t emitter;
 	yaml_event_t event;


### PR DESCRIPTION
typedef'd most structs and pulled a bunch of variables out of global. Removed `<struct>_raw_t` and `<struct>_handle_t` in favor of a more standard `<struct>_t` and updated functions to match. 